### PR TITLE
Ensure compatibility with react native projects, and adding possibility to initialise BBApplication with Application context

### DIFF
--- a/beaconbacon/src/main/java/dk/mustache/beaconbacon/BBApplication.java
+++ b/beaconbacon/src/main/java/dk/mustache/beaconbacon/BBApplication.java
@@ -39,8 +39,7 @@ public class BBApplication extends Application {
         return context;
     }
 
-    public void initialize(Context _context) {
-        super.onCreate();
+    public static void initialize(Context _context) {
         context = _context;
     }
 

--- a/beaconbacon/src/main/java/dk/mustache/beaconbacon/BBApplication.java
+++ b/beaconbacon/src/main/java/dk/mustache/beaconbacon/BBApplication.java
@@ -39,6 +39,11 @@ public class BBApplication extends Application {
         return context;
     }
 
+    public void initialize(Context _context) {
+        super.onCreate();
+        context = _context;
+    }
+
     @Override
     public void onCreate() {
         super.onCreate();

--- a/beaconbacon/src/main/java/dk/mustache/beaconbacon/fragments/PoiSelectionFragment.java
+++ b/beaconbacon/src/main/java/dk/mustache/beaconbacon/fragments/PoiSelectionFragment.java
@@ -115,6 +115,8 @@ public class PoiSelectionFragment extends Fragment implements PoiSelectionAdapte
 
     @Override
     public void removeAllPois() {
-        selectedPois.clear();
+        if(selectedPois!= null) {
+            selectedPois.clear();
+        }
     }
 }

--- a/beaconbacon/src/main/res/layout/find_book_snackbar.xml
+++ b/beaconbacon/src/main/res/layout/find_book_snackbar.xml
@@ -26,7 +26,6 @@
         android:layout_marginEnd="@dimen/general_horizontal_margin"
         android:layout_marginStart="@dimen/general_horizontal_margin"
         android:layout_toEndOf="@id/snack_image"
-        android:layout_toStartOf="@id/snack_action"
         android:gravity="center_vertical"
         android:orientation="vertical">
 

--- a/beaconbacon/src/main/res/layout/find_book_snackbar.xml
+++ b/beaconbacon/src/main/res/layout/find_book_snackbar.xml
@@ -19,6 +19,21 @@
         android:scaleType="fitCenter"
         app:srcCompat="@drawable/ic_no_padding_test" />
 
+    <Button
+        android:id="@+id/snack_action"
+        style="@style/Widget.AppCompat.Button.Borderless"
+        android:layout_width="80dp"
+        android:layout_height="wrap_content"
+        android:layout_alignParentEnd="true"
+        android:layout_centerVertical="true"
+        android:layout_marginBottom="@dimen/general_vertical_margin"
+        android:layout_marginTop="@dimen/general_vertical_margin"
+        android:background="@android:color/black"
+        android:text="Afslut"
+        android:textAllCaps="false"
+        android:textColor="@android:color/white"
+        android:textSize="12sp" />
+
     <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
@@ -26,6 +41,7 @@
         android:layout_marginEnd="@dimen/general_horizontal_margin"
         android:layout_marginStart="@dimen/general_horizontal_margin"
         android:layout_toEndOf="@id/snack_image"
+        android:layout_toStartOf="@id/snack_action"
         android:gravity="center_vertical"
         android:orientation="vertical">
 
@@ -45,19 +61,4 @@
             android:text="TextView"
             android:textSize="12sp" />
     </LinearLayout>
-
-    <Button
-        android:id="@+id/snack_action"
-        style="@style/Widget.AppCompat.Button.Borderless"
-        android:layout_width="80dp"
-        android:layout_height="wrap_content"
-        android:layout_alignParentEnd="true"
-        android:layout_centerVertical="true"
-        android:layout_marginBottom="@dimen/general_vertical_margin"
-        android:layout_marginTop="@dimen/general_vertical_margin"
-        android:background="@android:color/black"
-        android:text="Afslut"
-        android:textAllCaps="false"
-        android:textColor="@android:color/white"
-        android:textSize="12sp" />
 </RelativeLayout>

--- a/beaconbacon/src/main/res/values/strings.xml
+++ b/beaconbacon/src/main/res/values/strings.xml
@@ -14,7 +14,7 @@
     <string name="alert_title_general">Noget gik galt</string>
     <string name="alert_title_find_book">Lokation blev ikke fundet</string>
     <string name="alert_message_library">Vi kunne ikke finde noget kort til dette bibliotek.</string>
-    <string formatted="false" name="alert_message_find_book">\'%s\' blev ikke fundet på %s. Hvis du ikke kan finde lokationen, så husk du altid kan reservere direkte i app'en.</string>
+    <string formatted="false" name="alert_message_find_book">\'%s\' blev ikke fundet på %s. Hvis du ikke kan finde lokationen, så husk du altid kan reservere direkte i app\'en.</string>
 
     <string name="general_ok">OK</string>
     <string name="general_ok_dont_show_again">OK, vis ikke igen</string>

--- a/beaconbacon/src/main/res/values/strings.xml
+++ b/beaconbacon/src/main/res/values/strings.xml
@@ -14,7 +14,7 @@
     <string name="alert_title_general">Noget gik galt</string>
     <string name="alert_title_find_book">Lokation blev ikke fundet</string>
     <string name="alert_message_library">Vi kunne ikke finde noget kort til dette bibliotek.</string>
-    <string name="alert_message_find_book">\'%s\' blev ikke fundet på %s. Hvis du ikke kan finde lokationen, så husk du altid kan reservere direkte i app'en.</string>
+    <string formatted="false" name="alert_message_find_book">\'%s\' blev ikke fundet på %s. Hvis du ikke kan finde lokationen, så husk du altid kan reservere direkte i app'en.</string>
 
     <string name="general_ok">OK</string>
     <string name="general_ok_dont_show_again">OK, vis ikke igen</string>

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx1536m
-
+android.enableAapt2=false
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,6 +10,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx1536m
+android.enableAapt2=false
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,6 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx1536m
-android.enableAapt2=false
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit


### PR DESCRIPTION
- Compatibility with react native projects:
  - React native projects use gradle build tools version 2.2.3 -> beacon bacon lib uses version 3.0.1, which bundles resources using aapt2 - this causes beacon bacon lib to be compiled with aapt1, which causes several errors - these errors have been fixed.
- Initialise BBApplication:
  - If the project that uses beacon bacon lib has it own class that extends Application, the BBApplication class never gets initialised. A method has been added that makes it possible to initialise BBApplication with ones own application context.