### PR TITLE
Support for latest version of Picasso and Android Support libraries

### DIFF
--- a/beaconbacon/build.gradle
+++ b/beaconbacon/build.gradle
@@ -7,8 +7,8 @@ android {
 //        applicationId "dk.mustache.beaconbacon"
         minSdkVersion 19
         targetSdkVersion 28
-        versionCode 4
-        versionName "1.0.22"
+        versionCode 5
+        versionName "1.0.23"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }

--- a/beaconbacon/build.gradle
+++ b/beaconbacon/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
-apply plugin: 'com.github.dcendents.android-maven'
+//apply plugin: 'com.github.dcendents.android-maven'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
     defaultConfig {
 //        applicationId "dk.mustache.beaconbacon"
         minSdkVersion 19
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 4
         versionName "1.0.22"
 
@@ -24,16 +24,16 @@ android {
         javaMaxHeapSize "4g"
     }
 
-    buildToolsVersion '27.0.3'
+    buildToolsVersion '28.0.2'
 }
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
 
     //Support libraries
-    implementation 'com.android.support:appcompat-v7:27.1.1'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.2'
-    implementation 'com.android.support:design:27.1.1'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
+    implementation 'com.android.support:design:28.0.0'
 
     //Retrofit & GsonConverter
     implementation 'com.squareup.retrofit2:retrofit:2.4.0'
@@ -46,10 +46,7 @@ dependencies {
     implementation 'de.hdodenhof:circleimageview:2.1.0'
 
     //CircleImageView
-    implementation 'com.squareup.picasso:picasso:2.5.2'
-
-    //Picasso Image handling
-    implementation 'com.jakewharton.picasso:picasso2-okhttp3-downloader:1.1.0'
+    implementation 'com.squareup.picasso:picasso:2.71828'
 
     //Test libraries
     testImplementation 'junit:junit:4.12'

--- a/beaconbacon/src/main/java/dk/mustache/beaconbacon/api/ApiManager.java
+++ b/beaconbacon/src/main/java/dk/mustache/beaconbacon/api/ApiManager.java
@@ -3,7 +3,7 @@ package dk.mustache.beaconbacon.api;
 import android.content.Context;
 import android.support.annotation.NonNull;
 
-import com.jakewharton.picasso.OkHttp3Downloader;
+import com.squareup.picasso.OkHttp3Downloader;
 import com.squareup.picasso.Picasso;
 
 import java.io.IOException;

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 
     dependencies {
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.2.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,6 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx1536m
-android.enableAapt2=false
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-all.zip


### PR DESCRIPTION
Migrated to Picasso 2.71828 and removed picasso2-okhttp3-downloader.
Switched to compileSdkVersion 28 and 28.0.0 Support library versions.